### PR TITLE
Modernize python 2 codes

### DIFF
--- a/flare_emu.py
+++ b/flare_emu.py
@@ -160,7 +160,7 @@ class EmuHelper():
                 flow, paths = self.getPath(x.frm)
                 if flow is not None:
                     targetInfo[x.frm] = (flow, paths)
-        elif type(target) is list:
+        elif isinstance(target, list):
             for i, t in enumerate(target):
                 logging.debug("getting a path to %s, %d of %d" %
                               (self.hexString(t), i + 1, len(target)))
@@ -2031,7 +2031,7 @@ class EmuHelper():
                   uc.reg_write(self.regs[idc.print_operand(address, 0)], idc.get_operand_value(address, 1))
                   self.skipInstruction(userData)
 
-        except Exception, err:
+        except Exception as err:
             logging.debug("exception in emulateRange_codehook @%s: %s" % (self.hexString(address), str(err)))
             print("exception in emulateRange_codehook @%s: %s" % (self.hexString(address), str(err)))
             self.stopEmulation(userData)
@@ -2055,7 +2055,7 @@ class EmuHelper():
                               self.hexString(address))
                 return
 
-        except Exception, err:
+        except Exception as err:
             logging.debug("exception in emulateBytes_codehook @%s: %s" % (self.hexString(address), str(err)))
             print("exception in emulateBytes_codehook @%s: %s" % (self.hexString(address), str(err)))
             self.stopEmulation(userData)
@@ -2336,11 +2336,11 @@ class EmuHelper():
         mu.reg_write(self.regs["sp"], self.stack)
         for reg in registers:
             val = registers[reg]
-            if type(val) is str:
+            if isinstance(val, str):
                 mem = self.allocEmuMem(len(val))
                 mu.mem_write(mem, val)
                 val = mem
-            elif type(val) == int or type(val) == long:
+            elif isinstance(val, int) or isinstance(val, long):
                 pass
             else:
                 logging.debug("incorrect type for %s" % reg)
@@ -2350,12 +2350,12 @@ class EmuHelper():
 
         # setup stack
         for i in range(0, len(stack)):
-            if type(stack[i]) is str:
+            if isinstance(stack[i], str):
                 mem = self.allocEmuMem(len(stack[i]))
                 mu.mem_write(mem, stack[i])
                 stack[i] = mem
                 val = mem
-            elif type(stack[i]) == int or type(stack[i]) == long:
+            elif isinstance(stack[i], int) or isinstance(stack[i], long):
                 val = stack[i]
             else:
                 logging.debug("incorrect type for stack[%d]" % (i))

--- a/flare_emu.py
+++ b/flare_emu.py
@@ -37,6 +37,11 @@ ARMNOP = "\x00\xf0\x20\xe3"
 ARM64NOP = "\x1f\x20\x03\xd5"
 MAX_ALLOC_SIZE = 10 * 1024 * 1024
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 class EmuHelper():
     def __init__(self, verbose = 0):
         self.verbose = verbose
@@ -2340,7 +2345,7 @@ class EmuHelper():
                 mem = self.allocEmuMem(len(val))
                 mu.mem_write(mem, val)
                 val = mem
-            elif isinstance(val, int) or isinstance(val, long):
+            elif isinstance(val, (int, long)):
                 pass
             else:
                 logging.debug("incorrect type for %s" % reg)
@@ -2355,7 +2360,7 @@ class EmuHelper():
                 mu.mem_write(mem, stack[i])
                 stack[i] = mem
                 val = mem
-            elif isinstance(stack[i], int) or isinstance(stack[i], long):
+            elif isinstance(stack[i], (int, long)):
                 val = stack[i]
             else:
                 logging.debug("incorrect type for stack[%d]" % (i))

--- a/rename_dynamic_imports.py
+++ b/rename_dynamic_imports.py
@@ -43,7 +43,7 @@ def instructionHook(uc, address, size, userData):
                 makeName(idc.get_operand_value(address, 0), userData["imp"])
                 del(userData["imp"])
 
-    except Exception, err:
+    except Exception as err:
         print "Error in instructionHook: %s" % str(err)
         eh.stopEmulation(userData)
 
@@ -59,7 +59,7 @@ def callHook(address, argv, funcName, userData):
             # for code that checks for a return value
             eh.uc.reg_write(eh.regs["ret"], 1)
 
-    except Exception, err:
+    except Exception as err:
         print "Error in callHook: %s" % str(err)
         eh.stopEmulation(userData)
 


### PR DESCRIPTION
Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.

