### PR TITLE
flare_emu.py: Added a getEmuBytes function

### DIFF
--- a/flare_emu.py
+++ b/flare_emu.py
@@ -463,10 +463,7 @@ class EmuHelper():
 
     # returns a <size> string of bytes read from <addr>
     def getEmuBytes(self, addr, size):
-        out = ""
-        for i in range(addr, addr+size):
-            out += self.uc.mem_read(i, 1)
-        return out
+        return self.uc.mem_read(addr, size)
 
     # reads pointer value in emulator's memory
     def getEmuPtr(self, va):

--- a/flare_emu.py
+++ b/flare_emu.py
@@ -461,6 +461,13 @@ class EmuHelper():
             addr += 2
         return out
 
+    # returns a <size> string of bytes read from <addr>
+    def getEmuBytes(self, addr, size):
+        out = ""
+        for i in range(addr, addr+size):
+            out += self.uc.mem_read(i, 1)
+        return out
+
     # reads pointer value in emulator's memory
     def getEmuPtr(self, va):
         return struct.unpack(self.pack_fmt, self.uc.mem_read(va, self.size_pointer))[0]

--- a/flare_emu.py
+++ b/flare_emu.py
@@ -463,7 +463,7 @@ class EmuHelper():
 
     # returns a <size> string of bytes read from <addr>
     def getEmuBytes(self, addr, size):
-        return self.uc.mem_read(addr, size)
+        return str(self.uc.mem_read(addr, size))
 
     # reads pointer value in emulator's memory
     def getEmuPtr(self, va):


### PR DESCRIPTION
A more generic getEmuBytes function which returns a \<size\> long bytes string can be useful in some cases (for example, retrieving an encrypted stack string in order to decrypt it afterwards, ...).