### PR TITLE
add read_range_selection compatibility

### DIFF
--- a/flare_emu.py
+++ b/flare_emu.py
@@ -350,7 +350,10 @@ class EmuHelper():
     def emulateSelection(self, registers=None, stack=None, instructionHook=None, callHook=None,
                      memAccessHook=None, hookData=None, skipCalls=True, hookApis=True, count=0):
         import idaapi
-        selection = idaapi.read_selection()
+        try:
+            selection = idaapi.read_selection()
+        except TypeError:
+            selection = idaapi.read_range_selection(None)
         if selection[0]:
             self.emulateRange(selection[1], selection[2], registers, stack, instructionHook, 
                               callHook, memAccessHook, hookData, skipCalls, hookApis, count=count)


### PR DESCRIPTION
It seems that on the latest version of IDA PRO `read_selection()` expect 3 arguments. The Documentation confirms : [https://www.hex-rays.com/products/ida/support/idapython_docs/ida_kernwin-module.html#read_selection](https://www.hex-rays.com/products/ida/support/idapython_docs/ida_kernwin-module.html#read_selection).

On my IDA PRO 7.4.191112, Python 3.7.6 x64, Windows 10, I fixed the `TypeError` with this commit who preserve the older compatibility.