### PR TITLE
Force Type-Cast to Integer to avoid exceptions in Python3

### DIFF
--- a/flare_emu.py
+++ b/flare_emu.py
@@ -1586,17 +1586,17 @@ class EmuHelper():
         logging.debug("interrupt #%d received @%s" % ((intno), self.hexString(userData["currAddr"])))
         if self.arch == unicorn.UC_ARCH_X86:
             self.writeEmuMem(userData["currAddr"], X86NOP *
-                         userData["currAddrSize"])
+                         int(userData["currAddrSize"]))
         elif self.arch == unicorn.UC_ARCH_ARM:
             if self.mode == unicorn.UC_MODE_THUMB:
                 self.writeEmuMem(userData["currAddr"],
-                             ARMTHUMBNOP * (userData["currAddrSize"] / 2))
+                             ARMTHUMBNOP * int((userData["currAddrSize"] / 2)))
             else:
                 self.writeEmuMem(
-                    userData["currAddr"], ARMNOP * (userData["currAddrSize"] / 4))
+                    userData["currAddr"], ARMNOP * int((userData["currAddrSize"] / 4)))
         elif self.arch == unicorn.UC_ARCH_ARM64:
             self.writeEmuMem(
-                userData["currAddr"], ARM64NOP * (userData["currAddrSize"] / 4))
+                userData["currAddr"], ARM64NOP * int((userData["currAddrSize"] / 4)))
         self.enteredBlock = False
         return True
 


### PR DESCRIPTION
Hi:
The following snippets demonstrates the issue:

```
$ python2
Python 2.7.18 (default, May 23 2020, 12:02:55)
[GCC 9.3.0] on cygwin
Type "help", "copyright", "credits" or "license" for more information.
>>> type(4/4)
<type 'int'>
>>>
```

```
Python 3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> type(4/4)
<class 'float'>
```
